### PR TITLE
Perf/using map for open list find

### DIFF
--- a/src/lib/fastDownward/fastDownward.ts
+++ b/src/lib/fastDownward/fastDownward.ts
@@ -91,11 +91,13 @@ export async function search<LU extends LearningUnit>(
 	suggestionViolationPenalty = true
 ): Promise<Path | null> {
 	const openList: SearchNode<LU>[] = [new SearchNode<LU>(initialState, null, null, 0, 0)];
+	const openListStringArray : String[] = [];
 	const closedSet = new Set<string>();
 	while (openList.length > 0) {
 		//openList.sort((a, b) => a.heuristic - b.heuristic); // Replaced by inserting newNode to openList in sorted manner
 
 		const currentNode = openList.shift()!;
+		openListStringArray.shift()!;
 
 		/* Check if currentNode.state is the goal state */
 		if (currentNode.state.goalFulfilled(goal)) {
@@ -147,7 +149,12 @@ export async function search<LU extends LearningUnit>(
 			}
 
 			/* Check if node with same state is in openList */
-			const existingNode = openList.find(node => node.state.equal(newState));
+			const existingNodeIndex = openListStringArray.indexOf(newState.getHashCode());
+			let existingNode;
+			if (existingNodeIndex != -1) {
+				existingNode = openList.at(existingNodeIndex);
+			} 
+			
 			if (existingNode) {
 				if (newNode.cost < existingNode.cost) {
 					existingNode.cost = newNode.cost;
@@ -158,18 +165,19 @@ export async function search<LU extends LearningUnit>(
 				// Inserting newNode to openList in sorted manner
 				if (openList.length == 0) {
 					openList.push(newNode);
+					openListStringArray.push(newNode.state.getHashCode());
 				} else if (openList[openList.length - 1].heuristic < newNode.heuristic) {
 					openList.push(newNode);
+					openListStringArray.push(newNode.state.getHashCode());
 				} else {
 					for (let index = 0; index < openList.length; index++) {
 						if (newNode.heuristic <= openList[index].heuristic) {
 							openList.splice(index, 0, newNode);
+							openListStringArray.splice(index, 0, newNode.state.getHashCode());
 							break;
 						}
 					}
 				}
-
-				//openList.push(newNode);
 			}
 		}
 	}

--- a/src/lib/fastDownward/state.ts
+++ b/src/lib/fastDownward/state.ts
@@ -93,9 +93,22 @@ export class State {
 	}
 
 	deriveState(operator: LearningUnit, globalKnowledge: GlobalKnowledge) {
-		const mergedSkills = arrayUnique(
-			this.learnedSkills.concat(operator.teachingGoals.map(goal => goal.id))
-		);
+		
+		//const mergedSkills = arrayUnique(
+		//	this.learnedSkills.concat(operator.teachingGoals.map(goal => goal.id))
+		//);
+
+		const mergedSkills : string[] = [];
+		this.learnedSkills.forEach(skill => {
+			mergedSkills.push(skill);
+		});
+
+		operator.teachingGoals.forEach(goal => {
+			if (!mergedSkills.includes(goal.id)) {
+				mergedSkills.push(goal.id);
+			}
+		});
+		
 		return new State(mergedSkills, globalKnowledge);
 	}
 


### PR DESCRIPTION
perf: Using Map key-value instead of indexOf, Update deriveState
Replacing the openList indexOf operation with Map key-value object while checking if a node with the same state is in openList, update deriveState to enhance performance 